### PR TITLE
Specify std namespace for move

### DIFF
--- a/include/kf/DoubleLinkedListEntry.h
+++ b/include/kf/DoubleLinkedListEntry.h
@@ -13,7 +13,7 @@ namespace kf
 
         DoubleLinkedListEntry(DoubleLinkedListEntry&& other)
         {
-            *this = move(other);
+            *this = std::move(other);
         }
 
         ~DoubleLinkedListEntry()


### PR DESCRIPTION
Fix compilation issues due to usage of `move` without the `std `namespace specified